### PR TITLE
chore: fix typo in Sentry client comment

### DIFF
--- a/src/sentry.client.ts
+++ b/src/sentry.client.ts
@@ -1,5 +1,5 @@
 // This file configures the initialization of Sentry on the client.
-// The added config here will be used whenever a users loads a page in their browser.
+// The added config here will be used whenever a user loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";


### PR DESCRIPTION
## Summary
- fix typo in Sentry client header comment

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in multiple files)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6895baa9874c832f9accacd30fcaa9f7