### PR TITLE
chore: add Prettier to lint fix script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "lint:fix": "next lint --fix",
+    "lint:fix": "prettier --write . && next lint --fix",
     "type-check": "tsc --noEmit",
     "clean": "rm -rf .next out dist",
     "postinstall": "prisma generate",


### PR DESCRIPTION
## Summary
- run Prettier before ESLint in `npm run lint:fix`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6895bdc783d8832f840dd9f297e39ea9