### PR TITLE
test: add RBAC configuration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,12 @@ npm run lint:fix
 npm run type-check
 ```
 
+### Testing
+
+```bash
+npm test
+```
+
 ### Build & Deploy
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "next lint",
     "lint:fix": "prettier --write . && next lint --fix",
     "type-check": "tsc --noEmit",
+    "test": "node --test --experimental-strip-types",
     "clean": "rm -rf .next out dist",
     "postinstall": "prisma generate",
     "db:push": "prisma db push",

--- a/src/lib/__tests__/rbac.config.test.ts
+++ b/src/lib/__tests__/rbac.config.test.ts
@@ -1,0 +1,61 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  hasPermission,
+  hasAnyPermission,
+  hasAllPermissions,
+  canAccessRoute,
+} from '../rbac.config.ts';
+
+describe('RBAC utilities', () => {
+  describe('hasPermission', () => {
+    it('returns true for allowed permissions', () => {
+      assert.equal(hasPermission('admin', 'users:read'), true);
+    });
+    it('returns false for disallowed permissions', () => {
+      assert.equal(hasPermission('user', 'users:delete'), false);
+    });
+  });
+
+  describe('hasAnyPermission', () => {
+    it('returns true when at least one permission is allowed', () => {
+      assert.equal(
+        hasAnyPermission('support', ['users:create', 'profile:read']),
+        true
+      );
+    });
+    it('returns false when no permissions are allowed', () => {
+      assert.equal(
+        hasAnyPermission('user', ['reports:read', 'users:delete']),
+        false
+      );
+    });
+  });
+
+  describe('hasAllPermissions', () => {
+    it('returns true when all permissions are allowed', () => {
+      assert.equal(
+        hasAllPermissions('admin', ['users:read', 'users:create']),
+        true
+      );
+    });
+    it('returns false when any permission is missing', () => {
+      assert.equal(
+        hasAllPermissions('support', ['reports:read', 'reports:delete']),
+        false
+      );
+    });
+  });
+
+  describe('canAccessRoute', () => {
+    it('allows access to public routes', () => {
+      assert.equal(canAccessRoute('user', '/about'), true);
+    });
+    it('allows access to protected routes when permitted', () => {
+      assert.equal(canAccessRoute('admin', '/admin'), true);
+    });
+    it('denies access when role lacks permission', () => {
+      assert.equal(canAccessRoute('user', '/admin'), false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for RBAC helpers covering permissions and route access
- enable `npm test` via Node's built-in test runner
- document testing command in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895bec00bf8832f926a6162feb2067e