### PR TITLE
fix utils camelcase

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -105,9 +105,15 @@ export function toKebabCase(str: string): string {
 
 /**
  * Convert string to camelCase
+ * Ensures the first character is lowercase and subsequent separators
+ * (space, dash, underscore) are removed while capitalizing the following
+ * character.
  */
 export function toCamelCase(str: string): string {
-  return str.replace(/[-_\s]+(.)?/g, (_, c) => (c ? c.toUpperCase() : ''));
+  const formatted = str.replace(/[-_\s]+(.)?/g, (_, c) =>
+    c ? c.toUpperCase() : ''
+  );
+  return formatted.charAt(0).toLowerCase() + formatted.slice(1);
 }
 
 /**


### PR DESCRIPTION
## Summary
- ensure `toCamelCase` lowercases the first character and removes separators

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6895b49b3344832fa5c8c198b5b6c9f5