### PR TITLE
Fix asChild bug and add theme toggle

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,21 @@
-// app/layout.tsx
-import { AuthProvider } from '@/providers/AuthProvider';
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function HomePage() {
   return (
-    <html lang="th">
-      <body>
-        <AuthProvider>{children}</AuthProvider>
-      </body>
-    </html>
+    <main className="min-h-[calc(100vh-4rem)] flex items-center justify-center p-4">
+      <Card className="w-full max-w-md text-center">
+        <CardHeader>
+          <CardTitle>ระบบจัดการหอพัก</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-muted-foreground">เริ่มต้นใช้งานระบบจัดการห้องพักและผู้ใช้</p>
+          <Button asChild className="w-full">
+            <Link href="/login">เข้าสู่ระบบ</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </main>
   );
 }

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -3,6 +3,7 @@
 import { cn } from '@/lib/utils';
 import { cva, type VariantProps } from 'class-variance-authority';
 import React from 'react';
+import { Slot } from './Slot';
 
 const buttonVariants = cva(
   // Base styles
@@ -51,7 +52,7 @@ export interface ButtonProps
   rightIcon?: React.ReactNode;
 }
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+const Button = React.forwardRef<React.ElementRef<'button'>, ButtonProps>(
   (
     {
       className,
@@ -63,17 +64,19 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       rightIcon,
       children,
       disabled,
+      asChild = false,
       ...props
     },
     ref
   ) => {
     const isDisabled = disabled || loading;
+    const Comp = asChild ? Slot : 'button';
 
     return (
-      <button
+      <Comp
         className={cn(buttonVariants({ variant, size, fullWidth, className }))}
         ref={ref}
-        disabled={isDisabled}
+        {...(!asChild && { disabled: isDisabled })}
         {...props}
       >
         {loading && (
@@ -82,7 +85,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         {!loading && leftIcon && <span className="mr-2">{leftIcon}</span>}
         {children}
         {!loading && rightIcon && <span className="ml-2">{rightIcon}</span>}
-      </button>
+      </Comp>
     );
   }
 );

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -3,6 +3,7 @@
 import { cn } from '@/lib/utils';
 import { cva, type VariantProps } from 'class-variance-authority';
 import React from 'react';
+import { Slot } from './Slot';
 
 const cardVariants = cva(
   'rounded-lg border bg-card text-card-foreground shadow-sm',
@@ -39,14 +40,17 @@ export interface CardProps
   asChild?: boolean;
 }
 
-const Card = React.forwardRef<HTMLDivElement, CardProps>(
-  ({ className, variant, padding, hover, ...props }, ref) => (
-    <div
-      ref={ref}
-      className={cn(cardVariants({ variant, padding, hover }), className)}
-      {...props}
-    />
-  )
+const Card = React.forwardRef<React.ElementRef<'div'>, CardProps>(
+  ({ className, variant, padding, hover, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'div';
+    return (
+      <Comp
+        ref={ref}
+        className={cn(cardVariants({ variant, padding, hover }), className)}
+        {...props}
+      />
+    );
+  }
 );
 Card.displayName = 'Card';
 

--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import React, { useState } from 'react';
 import { Button } from './Button';
+import { ThemeToggle } from './ThemeToggle';
 
 export interface NavItem {
   label: {
@@ -94,6 +95,7 @@ export const Navbar: React.FC<NavbarProps> = ({
 
           {/* Right side actions */}
           <div className="flex items-center space-x-4">
+            <ThemeToggle />
             {/* Language Toggle */}
             {onLanguageChange && (
               <Button

--- a/src/components/ui/Slot.tsx
+++ b/src/components/ui/Slot.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface SlotProps extends React.HTMLAttributes<HTMLElement> {
+  children?: React.ReactNode;
+}
+
+const Slot = React.forwardRef<HTMLElement, SlotProps>(
+  ({ children, className, ...props }, ref) => {
+    if (!React.isValidElement(children)) {
+      return null;
+    }
+
+    const child = children as React.ReactElement<Record<string, unknown>>;
+    return React.cloneElement(child, {
+      ...props,
+      ref,
+      className: cn((child.props as { className?: string }).className, className),
+    });
+  }
+);
+Slot.displayName = 'Slot';
+
+export { Slot };

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useTheme } from '@/hooks/useTheme';
+import { Button } from './Button';
+import { Moon, Sun } from 'lucide-react';
+import React from 'react';
+
+export function ThemeToggle() {
+  const { toggleMode, isDark } = useTheme();
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleMode}
+      aria-label="Toggle theme"
+    >
+      {isDark ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- handle `asChild` in Button and Card via custom Slot component
- add ThemeToggle and integrate into Navbar
- create responsive centered home page

## Testing
- `npm run lint` *(fails: Unexpected any and other existing issues)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6895e0cd609c832f8791ad0e351c1752